### PR TITLE
Dockerenv

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
 	"name": "Nerves",
 	// Pull Docker image from DockerHub  https://hub.docker.com/r/nervesjp/nerves
-	"image": "nervesjp/nerves:0.1.1",
+	"image": "nervesjp/nerves:0.2",
 	// NOTE: original Dockerfile is maintained at https://github.com/NervesJP/docker-nerves/blob/main/Dockerfile
 	// You can also build Docker image locally by locating above file to here and uncomment next line 
 	//"dockerFile": "Dockerfile",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,7 +18,14 @@
 	
 	"extensions": [
 		"jakebecker.elixir-ls"
-	]
+	],
+
+	// This section sets environment variables for Nerves development
+	"remoteEnv": {
+		"MIX_TARGET": "rpi3",
+		"WIFI_SSID": "xxxxxxxx",
+		"WIFI_PSK": "yyyyyyyy"
+	}
 
 	// Uncomment to connect as a non-root user. More info: https://aka.ms/vscode-remote/containers/non-root.
 	//"remoteUser": "vscode"

--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ Nerves development workspace with Visual Studio Code dev-container (Remote - Con
 ## Quick start
 
 1. Clone this repository  
-```Shell
+```shell-session
 git clone https://github.com/NervesJP/nerves-devcontainer
 ```
 
 2. Start VS Code, run the **Remote-Containers: Open Folder in Container...** command from the Command Palette (F1) or quick actions Status bar item, and select the project folder you cloned at Step 1.
 
 3. After a while, you can enjoy Nerves/Elixir development with Bash on Docker image and VS Code like as follows.  
-```Shell
+```shell-session
 root@ebc5e1a19ae3:/workspaces/nerves-devcontainer# ls 
 LICENSE.txt  README.md
 root@ebc5e1a19ae3:/workspaces/nerves-devcontainer# ls ~/.mix/*
@@ -40,7 +40,7 @@ iex(1)>
 ```
 
 4. Note that you need to generate your SSH keys, only for the first time to login Docker image.
-```Shell
+```shell-session
 root@ebc5e1a19ae3:/workspaces/nerves-devcontainer# ssh-keygen -t rsa -N "" -f .ssh/id_rsa
 ```
 
@@ -82,7 +82,7 @@ https://github.com/fhunleth/fwup
 
 After installing `fwup` on the host according to [this step](https://github.com/fhunleth/fwup#installing), please do following command on the host terminal (e.g., PowerShell as Administrator, Terminal.app).
 
-```Shell
+```shell-session
 $ cd <your_nerves_project_dir>
 $ fwup _build/${MIX_TARGET}_dev/nerves/images/<project_name>.fw
 ```

--- a/README.md
+++ b/README.md
@@ -73,6 +73,15 @@ To generate your SSH keys, you need to operate `ssh-keygen -t rsa -N "" -f /work
 
 In addition, your Nerves project can be kept on the current directory by the VS Code automatic feature.
 
+### Set environment variables for Nerves development
+
+You can set your own environment variables with `remoteEnv` option in `./devcontainer/devcontainer.json`.
+
+By default, `${MIX_TARGET}` is set to `rpi3` when runing the dev-container.
+Please change the value accordingly if your [target of Nerves](https://hexdocs.pm/nerves/targets.html) is already determined by something other than rpi3.
+
+In addition to this, here we define environment variables for WiFi settings. You may set these values of `${WIFI_SSID}` and `${WIFI_PSK}` according to the WiFi access point. See ["Connect to a target device" on this article](https://dev.to/mnishiguchi/elixir-nerves-get-started-with-led-blinking-on-raspberry-pi-2l1i) for details.
+
 ### Burn Nerves firmware to microSD card
 
 Docker has restrict policies to avoid effecting host environment. And also, it is not possible to pass through a USB device (or a serial port) to a container as it requires support at the hypervisor level both in [Windows](https://docs.docker.com/docker-for-windows/faqs/#can-i-pass-through-a-usb-device-to-a-container) and [macOS](https://docs.docker.com/docker-for-mac/faqs/#can-i-pass-through-a-usb-device-to-a-container) as the host.  

--- a/README.md
+++ b/README.md
@@ -75,16 +75,25 @@ In addition, your Nerves project can be kept on the current directory by the VS 
 
 ### Burn Nerves firmware to microSD card
 
-Docker has restrict policies to avoid effecting host environment. Therefore, `mix burn` cannot be operated from Docker image because there is no right to access `/dev` to on host as a root user.
+Docker has restrict policies to avoid effecting host environment. And also, it is not possible to pass through a USB device (or a serial port) to a container as it requires support at the hypervisor level both in [Windows](https://docs.docker.com/docker-for-windows/faqs/#can-i-pass-through-a-usb-device-to-a-container) and [macOS](https://docs.docker.com/docker-for-mac/faqs/#can-i-pass-through-a-usb-device-to-a-container) as the host.  
+Therefore, `mix burn` cannot be operated from Docker image because there is no right to access `/dev` to on host as a root user.
 
 One way to burn Nerves firmware is just operating `fwup` on the host. `fwup` is an utility for constructing/burning Nerves firmware.  
 https://github.com/fhunleth/fwup
 
-After installing `fwup` on the host according to [this step](https://github.com/fhunleth/fwup#installing), please do following command on the host terminal (e.g., PowerShell as Administrator, Terminal.app).
+After installing `fwup` on the host according to [this step](https://github.com/fhunleth/fwup#installing), please do following command on the host terminal (e.g., PowerShell **as Administrator**, Terminal.app).
 
 ```shell-session
 $ cd <your_nerves_project_dir>
 $ fwup _build/${MIX_TARGET}_dev/nerves/images/<project_name>.fw
+```
+
+If you are using Linux as the host, you may be able to access microSD from the Docker environment along with the `privileged` option.
+You may need to use a different `/dev/` address for your purposes.
+
+```shell-session
+$ docker run -it -w /workspace -v ${PWD}:/workspace \\
+  -v /dev/sdb:/dev/sdb --privileged docker-nerves 
 ```
 
 Please let us know if you have a cool solution! ([issue#1](https://github.com/NervesJP/docker-nerves/issues/1))


### PR DESCRIPTION
- Bump v0.2 to pre-built image
- add `remoteEnv` to set environment variables for Nerves development
- add Tips to burn the firmware only on Linux as the host
